### PR TITLE
Fix args out of range error when switching between buffers

### DIFF
--- a/highlight-indent-guides.el
+++ b/highlight-indent-guides.el
@@ -780,6 +780,10 @@ This function is designed to run from the `after-make-frame-functions' hook."
       (setq highlight-indent-guides--idle-timer nil))
     (if highlight-indent-guides-mode
         (progn
+          ;; set highlight-indent-guides--line-cache so it becomes buffer-local
+          ;; After this, we can destructively modify it just fine, as every
+          ;; buffer has a unique object.
+          (setq highlight-indent-guides--line-cache (list nil nil nil))
           (unless (daemonp) (highlight-indent-guides-auto-set-faces))
           (add-to-list 'after-make-frame-functions
                        'highlight-indent-guides--auto-set-faces-with-frame)

--- a/highlight-indent-guides.el
+++ b/highlight-indent-guides.el
@@ -21,7 +21,7 @@
 ;; SOFTWARE.
 ;;
 ;; Author: DarthFennec <darthfennec@derpymail.org>
-;; Version: 0.8.1
+;; Version: 0.8.2
 ;; Package-Requires: ((emacs "24"))
 ;; URL: https://github.com/DarthFennec/highlight-indent-guides
 


### PR DESCRIPTION
Sometimes, when switching from a large buffer to a smaller buffer, I got:

```
Debugger entered--Lisp error: (args-out-of-range 2354 6378)
  put-text-property(#<marker at 2354 in my-packages.el> #<marker at 6378 in my-packages.el> fontified nil)
  jit-lock-refontify(#<marker at 2354 in my-packages.el> #<marker at 6378 in my-packages.el>)
  font-lock-flush(#<marker at 2354 in my-packages.el> #<marker at 6378 in my-packages.el>)
  highlight-indent-guides--try-update-line-cache()
  apply(highlight-indent-guides--try-update-line-cache nil)
  timer-event-handler([t 0 0 100000 t highlight-indent-guides--try-update-line-cache nil idle 0])
```

This is because the idle cache variable, despite being buffer local, was reading and setting a global value, causing cache values from previous buffers to be used in the timer function. This is because buffer-local variables become buffer local on a set, not on side-effects. This modifies the destructive operations to become non-destructive, and uses `setq` explicitly to set the variable as buffer-local. This could negatively impact performance, but I haven't noticed anything so far.

Let me know if you spot anything wrong :) 
