### PR TITLE
Stop updating line cache when mode is disabled

### DIFF
--- a/highlight-indent-guides.el
+++ b/highlight-indent-guides.el
@@ -280,7 +280,8 @@ function is called whenever the current line data changes."
   "Update the line cache, if necessary.
 This function is called whenever the point moves in a way that might change the
 line cache.  It only updates the cache when absolutely necessary."
-  (when highlight-indent-guides-responsive
+  (when (and highlight-indent-guides-responsive
+             highlight-indent-guides-mode)
     (let ((cached-pt (car highlight-indent-guides--line-cache))
           (cached-ln (nth 1 highlight-indent-guides--line-cache))
           (cached-dt (nth 2 highlight-indent-guides--line-cache))


### PR DESCRIPTION
See #38

I think there is one more edge case. Since the timer is always running, it will update the line cache even for buffers not part of the minor mode. Since the minor mode is not initialized in those buffers, they don't have a buffer local variable. By avoiding updating the cache for those buffer entirely, we shouldn't run into this any more.