### PR TITLE
Add instructions for installation via GNU Guix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ Installation
 ------------
 
 To install from [Melpa](http://melpa.org/#/getting-started), use <kbd>M-x
-package-install RET highlight-indent-guides RET</kbd>. Otherwise, download
-`highlight-indent-guides.el` and put it in your load path.
+package-install RET highlight-indent-guides RET</kbd>.
+
+To install from [GNU Guix](https://guix.gnu.org/), run `guix install
+emacs-highlight-indent-guides`.
+
+ Otherwise, download `highlight-indent-guides.el` and put it in your load path.
 
 Usage
 -----


### PR DESCRIPTION
The recipe was added in https://git.savannah.gnu.org/cgit/guix.git/commit/?id=bdea16a8e6f860b3851340484c5cfcbfca106cc6.